### PR TITLE
增加了epub导入

### DIFF
--- a/controllers/BookController.go
+++ b/controllers/BookController.go
@@ -24,6 +24,7 @@ import (
 	"github.com/TruthHun/BookStack/utils"
 	"github.com/TruthHun/gotil/filetil"
 	"github.com/TruthHun/gotil/mdtil"
+	"github.com/TruthHun/html2md"
 	"github.com/TruthHun/gotil/util"
 	"github.com/TruthHun/gotil/ziptil"
 	"github.com/astaxie/beego"
@@ -980,14 +981,23 @@ func (this *BookController) unzipToData(bookId int, identify, zipFile, originFil
 								beego.Error(err)
 							}
 						}
-					} else if ext == ".md" || ext == ".markdown" { //markdown文档，提取文档内容，录入数据库
+					} else if ext == ".md" || ext == ".markdown" || ext == ".html" { //markdown文档，提取文档内容，录入数据库
 						doc := new(models.Document)
+						var mdcont string 
+						var htmlStr string 
 						if b, err := ioutil.ReadFile(file.Path); err == nil {
-							mdcont := strings.TrimSpace(string(b))
+
+							if ext == ".md" || ext == ".markdown" {
+								mdcont = strings.TrimSpace(string(b))
+								
+								htmlStr = mdtil.Md2html(mdcont)
+							}else {
+								htmlStr = string(b)
+								mdcont =  html2md.Convert(htmlStr)
+							}
 							if !strings.HasPrefix(mdcont, "[TOC]") {
 								mdcont = "[TOC]\r\n\r\n" + mdcont
 							}
-							htmlStr := mdtil.Md2html(mdcont)
 							doc.DocumentName = utils.ParseTitleFromMdHtml(htmlStr)
 							doc.BookId = bookId
 							//文档标识

--- a/controllers/BookController.go
+++ b/controllers/BookController.go
@@ -915,8 +915,8 @@ func (this *BookController) UploadProject() {
 		this.JsonResult(1, err.Error())
 	}
 	defer f.Close()
-	if strings.ToLower(filepath.Ext(h.Filename)) != ".zip" {
-		this.JsonResult(1, "请上传zip格式文件")
+	if strings.ToLower(filepath.Ext(h.Filename)) != ".zip" && strings.ToLower(filepath.Ext(h.Filename)) != ".epub" {
+		this.JsonResult(1, "请上传指定格式文件")
 	}
 	tmpFile := "store/" + identify + ".zip" //保存的文件名
 	if err := this.SaveToFile("zipfile", tmpFile); err == nil {
@@ -1004,7 +1004,7 @@ func (this *BookController) unzipToData(bookId int, identify, zipFile, originFil
 							//文档标识
 							doc.Identify = strings.Replace(strings.Trim(strings.TrimPrefix(file.Path, projectRoot), "/"), "/", "-", -1)
 							doc.Identify = strings.Replace(doc.Identify, ")", "", -1)
-							
+
 							doc.MemberId = this.Member.MemberId
 							doc.OrderSort = 1
 							if strings.HasSuffix(strings.ToLower(file.Name), "summary.md") {

--- a/models/store/local.go
+++ b/models/store/local.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"os"
+	"io/ioutil"
 	"path/filepath"
 	"strings"
 )
@@ -31,7 +32,12 @@ func (this *Local) MoveToStore(tmpfile, save string) (err error) {
 	if strings.ToLower(tmpfile) != strings.ToLower(save) { //不是相同文件路径
 
 		os.MkdirAll(filepath.Dir(save), os.ModePerm)
-		err = os.Rename(tmpfile, save)
+		// 不使用rename，因为在docker中会挂载外部卷，导致错误
+		// 见https://gocn.vip/article/178
+		if b, err := ioutil.ReadFile(tmpfile); err == nil {
+			ioutil.WriteFile(save, b, os.ModePerm)
+		}
+		os.Remove(tmpfile)
 	}
 	return
 }

--- a/views/book/index.html
+++ b/views/book/index.html
@@ -49,6 +49,11 @@
                             <input type="file" name="zipfile" accept="application/zip">
                             <input type="text" name="identify" value="">
                             </form>
+
+                            <form target="notarget" style="display: none;" action="{{urlfor "BookController.UploadProject"}}" enctype="multipart/form-data" method="post" id="uploadEpub">
+                                <input type="file" name="zipfile" accept=".epub">
+                                <input type="text" name="identify" value="">
+                            </form>
                             <div class="list-item clearfix" v-for="item in lists">
                                 <div class="col-sm-2 col-xs-12" style="padding-left: 0px">
                                     <a :class="item.order_index ? 'recommend-book' : ''" :href="'{{urlfor "DocumentController.Index" ":key" ""}}' + item.identify" title="查看文档" data-toggle="tooltip">
@@ -115,6 +120,11 @@
                                                 <span class="sr-only">Toggle Dropdown</span>
                                             </button>
                                             <ul class="dropdown-menu">
+                                                <li>
+                                                    <a href="javascript:void(0);" class="btn-upload-epub" data-toggle="tooltip" :data-identify="item.identify" title="支持epub格式电子书导入。">
+                                                        <i class="fa fa-cloud-upload"></i> EPUB 上传导入
+                                                    </a>
+                                                </li>
                                                 <li>
                                                     <a href="javascript:void(0);" class="btn-upload-zip" data-toggle="tooltip" :data-identify="item.identify" title="支持任意zip压缩的markdown项目导入。">
                                                         <i class="fa fa-cloud-upload"></i> ZIP 上传导入
@@ -304,6 +314,21 @@
             if($(this).val() && confirm("您确定要上传 "+$(this).val()+" 吗？")){
                 $(".btn-upload-zip").addClass("disabled");
                 $("#uploadZip").submit();
+            }
+        });
+
+         //批量上传文档图片[要放在vue执行代码的后面，否则获取不到identify的值]
+         $(".btn-upload-epub").click(function () {
+            var _this=$(this),identify=_this.attr("data-identify"),form=$("form#uploadEpub");
+            form.find("[name=identify]").val(identify);
+            form.find("input[type=file]").trigger("click");
+        });
+
+        //change事件处理
+        $("#uploadEpub input[type=file]").change(function () {
+            if($(this).val() && confirm("您确定要上传 "+$(this).val()+" 吗？")){
+                $(".btn-upload-epub").addClass("disabled");
+                $("#uploadEpub").submit();
             }
         });
 


### PR DESCRIPTION
epub实际上就是zip压缩的文件，复用一些zip包的代码即可实现epub的上传与导入。

另外，发现在用docker时，uploads目录是通过-v挂载到容器中的，导致go语言的rename报错。使用read, write解决。