### PR TITLE
fix bug in doc searching within a book

### DIFF
--- a/controllers/api/CommonController.go
+++ b/controllers/api/CommonController.go
@@ -477,7 +477,7 @@ func (this *CommonController) SearchDoc() {
 		}
 		total = count
 		for _, book := range result {
-			ids = append(ids, book.BookId)
+			ids = append(ids, book.DocumentId)
 		}
 	}
 


### PR DESCRIPTION
fix bug in doc searching within a book: when using db query, bookId was used as DocId in former versions