### PR TITLE
Update app.conf.example

### DIFF
--- a/conf/app.conf.example
+++ b/conf/app.conf.example
@@ -99,8 +99,8 @@ db_database=bookstack
 
 # 谷歌浏览器，用于发布内容的时候渲染未被渲染的markdown。建议安装最新版的Chrome浏览器，并把Chrome浏览器加入系统环境变量。
 # 使用Chrome的headless去处理。之前考虑使用phantomjs的，但是phantomjs有些小问题，不如Chrome强大。
-# chrome=chromium-browser
-chrome=/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome
+chrome=chromium-browser
+# chrome=/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome
 
 # 如果使用 puppeteer，则忽略chrome
 puppeteer = false


### PR DESCRIPTION
默认的chrome=/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome参数配置，在批量发布文档的时候，会报错，类似于
```2020/03/31 19:47:14.477  [util.go:176]  fork/exec /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome: no such file or directory 
2020/03/31 19:47:14.489  [util.go:168]  render document by document_id: [/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --headless --disable-gpu --screenshot --no-sandbox --window-size=320,480 http://localhost:8181/local-render?id=108] 
```